### PR TITLE
add option to delete releases but not tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Remove tags which do not have an associated release'
     required: false
     default: 'false'
+  remove_tags:
+    description: 'Delete tags in addition to releases'
+    required: false
+    default: 'true'
   dry_run:
     description: 'Do not actually delete releases'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -31848,6 +31848,7 @@ async function main() {
   const dryRun = core.getInput('dry_run') === 'true'
   const lastTagFile = core.getInput('last_tag_file')
   const removeTagsWithoutRelease = core.getInput('remove_tags_without_release') === 'true'
+  const removeTags = core.getInput('remove_tags') === 'true'
 
   const octokit = github.getOctokit(process.env.GITHUB_TOKEN).rest
   const { owner, repo } = context.repo
@@ -31890,9 +31891,11 @@ async function main() {
         console.log(`\nDeleting ${formatRelease(release)}`)
         await octokit.repos.deleteRelease({ owner, repo, release_id: release.id })
 
-        const tag = release.tag_name
-        console.log(`Deleting tag ${tag}`)
-        await deleteTag(tag)
+        if (removeTags) {
+          const tag = release.tag_name
+          console.log(`Deleting tag ${tag}`)
+          await deleteTag(tag)
+        }
       }
     }
     core.endGroup()

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ async function main() {
   const dryRun = core.getInput('dry_run') === 'true'
   const lastTagFile = core.getInput('last_tag_file')
   const removeTagsWithoutRelease = core.getInput('remove_tags_without_release') === 'true'
-  const removeTags = core.getInput('remove_tags') !== 'false'
+  const removeTags = core.getInput('remove_tags') === 'true'
 
   const octokit = github.getOctokit(process.env.GITHUB_TOKEN).rest
   const { owner, repo } = context.repo

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ async function main() {
   const dryRun = core.getInput('dry_run') === 'true'
   const lastTagFile = core.getInput('last_tag_file')
   const removeTagsWithoutRelease = core.getInput('remove_tags_without_release') === 'true'
+  const removeTags = core.getInput('remove_tags') !== 'false'
 
   const octokit = github.getOctokit(process.env.GITHUB_TOKEN).rest
   const { owner, repo } = context.repo
@@ -54,9 +55,11 @@ async function main() {
         console.log(`\nDeleting ${formatRelease(release)}`)
         await octokit.repos.deleteRelease({ owner, repo, release_id: release.id })
 
-        const tag = release.tag_name
-        console.log(`Deleting tag ${tag}`)
-        await deleteTag(tag)
+        if (removeTags) {
+          const tag = release.tag_name
+          console.log(`Deleting tag ${tag}`)
+          await deleteTag(tag)
+        }
       }
     }
     core.endGroup()


### PR DESCRIPTION
Hello,

This is a small addition to allow deleting releases, but not the associated tags. Useful when you're using `git push --tags`: if the tag was deleted on remote by this action, then the old tag is pushed again, triggering a new release. This new input prevents that.  

Thank you for this github action.